### PR TITLE
Make it possible to extend a chain without polluting prototype

### DIFF
--- a/test/zhain-test.js
+++ b/test/zhain-test.js
@@ -224,11 +224,32 @@ describe('zhain-test', function() {
   })
 
   describe('utils', function() {
-    it('extending', function(done) {
+    it('extending with prototype', function(done) {
       z().pow().run(function(err, res) {
         assert.equal(res, 'pow')
         done()
       })
+    })
+
+    it('extending without prototype', function(done) {
+      z()
+        .extend('bang', function() { return this.do(function() { return 'bang' }) })
+        .bang()
+        .run(function(err, res) {
+          assert.equal(res, 'bang')
+          done()
+        })
+    })
+
+    it('non-prototype extensions stay between runs', function(done) {
+      var chain1 = z().extend('boom', function() { return this.do(function() { return 'boom' }) })
+        .pow()
+        .do(function(err, res) {
+          assert.equal(res, 'boom')
+        }).end()
+      chain1()
+      chain1()
+      done()
     })
 
     it('sleep()', function(done) {

--- a/zhain.js
+++ b/zhain.js
@@ -45,6 +45,11 @@ function Zhain(parent, fn) {
     })
   }
 
+  Zhain.prototype.extend = function(fnName, fn) {
+    this[fnName] = fn
+    return this
+  }
+
   Zhain.prototype.log = function(string) {
     return this.sync(function() { console.log(string || arguments) })
   }


### PR DESCRIPTION
When extending prototype, we might get namespace collusions if we wanted to create multiple different domain-specific extensions. Instead we could extend each chain separately, with a simple z().extend method.

Code attached. What do you think?
